### PR TITLE
feat: deploy.sh wrapper that enforces keystore signing on non-anvil chains

### DIFF
--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -1,10 +1,22 @@
-# for deployment
-DEPLOYER_PRIVATE_KEY=
-DEPLOYER_WALLET_ADDRESS=
+# Deployment -- consumed by script/deploy/deploy.sh.
+#
+# Signing: deploy.sh REJECTS a plaintext DEPLOYER_PRIVATE_KEY on any chain
+# other than 31337 (local anvil). For real chains, sign via a foundry
+# keystore account (`--account <name>`, after `cast wallet import`) or a
+# hardware wallet (`--ledger`).
+
 RPC_URL=
 
-# for verification on explorers
+# Plaintext signing key -- ONLY used on chain id 31337 (anvil). Leave blank
+# for any real chain and pass --account / --ledger to deploy.sh instead.
+DEPLOYER_PRIVATE_KEY=
+
+# Optional: enables Etherscan auto-verification (`--verify`).
 ETHERSCAN_API_KEY=
+
+# Optional: override verifier (e.g. for Blockscout-family explorers)
+# VERIFIER=blockscout
+# VERIFIER_URL=https://<host>/api/
 
 {% if cookiecutter.use_tenderly == 'y' %}# for Tenderly Virtual TestNets
 TENDERLY_ACCESS_KEY=

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -56,13 +56,56 @@ Each testing approach exposes different types of vulnerabilities in the contract
 
 ## Deployment
 
-Deploy contracts using Foundry's native scripting:
+Deployments go through `script/deploy/deploy.sh`, a thin wrapper around
+`forge script` that enforces keystore-based signing on any real chain --
+a plaintext `DEPLOYER_PRIVATE_KEY` is **rejected** unless the RPC reports
+chain id `31337` (local anvil).
+
+### 1. Import the signing key (one-time)
 
 ```bash
-forge script script/deploy/<YourScript>.s.sol --rpc-url <your_rpc_url> --private-key <your_private_key> --broadcast
+# encrypts the key with a password, stored at ~/.foundry/keystores/my-deployer
+cast wallet import my-deployer --interactive
+cast wallet address --account my-deployer   # confirm the address, fund it
 ```
 
-For more information, consult the [Foundry Book](https://book.getfoundry.sh/).
+Hardware-wallet alternative: pass `--ledger` to `deploy.sh` (skip this step).
+
+### 2. Configure `.env`
+
+```bash
+cp .env.example .env
+# edit:
+#   RPC_URL=...                          (required)
+#   ETHERSCAN_API_KEY=...                (optional, enables auto-verify)
+#   VERIFIER=blockscout                  (optional, for non-Etherscan explorers)
+#   VERIFIER_URL=https://<host>/api/     (optional, required for Blockscout)
+#
+# Leave DEPLOYER_PRIVATE_KEY empty -- pass --account or --ledger instead.
+```
+
+### 3. Dry-run, then broadcast
+
+```bash
+# simulate first (no broadcast)
+script/deploy/deploy.sh script/deploy/Deploy.s.sol --dry-run --account my-deployer
+
+# broadcast (forge prompts for the keystore password once)
+script/deploy/deploy.sh script/deploy/Deploy.s.sol           --account my-deployer
+
+# hardware-wallet form (prompts on the device)
+script/deploy/deploy.sh script/deploy/Deploy.s.sol           --ledger
+```
+
+`script/deploy/deploy.sh --help` lists every supported variable and flag,
+including passthrough (`--`) for forwarding `--sig`, `--target-contract`,
+env-arg syntax, etc. to `forge script`.
+
+Local anvil only: `DEPLOYER_PRIVATE_KEY` in `.env` is accepted **only**
+when the RPC returns chain id `31337`. Anything else is a hard error
+pointing you at `cast wallet import`.
+
+For more on Foundry scripting, see the [Foundry Book](https://book.getfoundry.sh/).
 
 ## Tenderly Virtual TestNets
 

--- a/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
+++ b/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Deploy a Foundry script with a keystore-signed transaction.
+#
+# Usage:
+#   script/deploy/deploy.sh <forge-script-path> [flags]
+#
+# Examples:
+#   script/deploy/deploy.sh script/deploy/Deploy.s.sol      --account my-deployer
+#   script/deploy/deploy.sh script/deploy/MyScript.s.sol    --dry-run --account my-deployer
+#   script/deploy/deploy.sh script/deploy/MyScript.s.sol    --ledger
+#
+# Configuration is read from a `.env` file in the repo root (gitignored).
+#   RPC_URL                JSON-RPC endpoint of the target chain  (required)
+#   ETHERSCAN_API_KEY      explorer API key; enables `--verify`   (optional)
+#   VERIFIER               "etherscan" | "blockscout" | "sourcify" (optional)
+#   VERIFIER_URL           verifier API URL (required for Blockscout) (optional)
+#   DEPLOYER_PRIVATE_KEY   plaintext signing key. REJECTED on any chain
+#                          other than 31337 (local anvil). For mainnet /
+#                          testnet, sign via --account or --ledger so the
+#                          key never lives on disk in plaintext.
+#
+# Signing (pick one for any real chain):
+#   --account NAME         sign with a foundry keystore account (recommended).
+#                          One-time setup: `cast wallet import NAME --interactive`.
+#                          Forge prompts for the keystore password at sign time.
+#   --ledger               sign with a connected Ledger hardware wallet.
+#
+# Flags:
+#   --dry-run              simulate only; do not broadcast (default: broadcast)
+#   --no-verify            skip contract verification even if a key is configured
+#   --                     forward all subsequent args verbatim to `forge script`
+#                          (useful for --sig, --target-contract, env-arg passthrough)
+#   -h | --help            show this help and exit
+#
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# locate repo root, load .env
+# ----------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a; source "$REPO_ROOT/.env"; set +a
+fi
+
+die()  { echo "error: $*" >&2; exit 1; }
+note() { echo ">>> $*" >&2; }
+warn() { echo "warning: $*" >&2; }
+
+usage() { sed -n '2,/^set -euo/{/^set -euo/!p}' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+# ----------------------------------------------------------------------------
+# parse args
+# ----------------------------------------------------------------------------
+SCRIPT_PATH="${1:-}"
+[[ -z "$SCRIPT_PATH" || "$SCRIPT_PATH" == "-h" || "$SCRIPT_PATH" == "--help" ]] && { usage; exit 0; }
+shift
+
+BROADCAST=1
+DO_VERIFY=1
+SIGNER_ARGS=()
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   BROADCAST=0; shift ;;
+    --no-verify) DO_VERIFY=0; shift ;;
+    --account)   [[ -n "${2:-}" ]] || die "--account needs a name"; SIGNER_ARGS=(--account "$2"); shift 2 ;;
+    --ledger)    SIGNER_ARGS=(--ledger); shift ;;
+    -h|--help)   usage; exit 0 ;;
+    --)          shift; EXTRA_ARGS=("$@"); break ;;
+    *)           die "unknown flag: $1 (see --help)" ;;
+  esac
+done
+
+[[ -f "$SCRIPT_PATH" ]] || die "script not found: $SCRIPT_PATH"
+
+# ----------------------------------------------------------------------------
+# validate config
+# ----------------------------------------------------------------------------
+: "${RPC_URL:?set RPC_URL}"
+
+CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL")"
+note "target chain id: $CHAIN_ID"
+
+# Plaintext DEPLOYER_PRIVATE_KEY is only accepted against a local anvil
+# (chain id 31337). For any other chain (mainnet, testnet, sidechain, ...)
+# require a foundry keystore account (`--account NAME`) or a hardware wallet
+# (`--ledger`) so the signing key never lives on disk in plaintext.
+if [[ ${#SIGNER_ARGS[@]} -eq 0 ]]; then
+  if [[ "$CHAIN_ID" -ne 31337 ]]; then
+    die "plaintext DEPLOYER_PRIVATE_KEY is not allowed on chain $CHAIN_ID.
+       Import the key once into foundry's encrypted keystore:
+         cast wallet import <name> --interactive
+       then deploy with:
+         script/deploy/deploy.sh $SCRIPT_PATH --account <name>
+       (or sign with a hardware wallet via --ledger)."
+  fi
+  : "${DEPLOYER_PRIVATE_KEY:?set DEPLOYER_PRIVATE_KEY (anvil only) or pass --account / --ledger}"
+  warn "using plaintext DEPLOYER_PRIVATE_KEY against chain $CHAIN_ID (anvil) -- only acceptable for local dev"
+  SIGNER_ARGS=(--private-key "$DEPLOYER_PRIVATE_KEY")
+fi
+
+# ----------------------------------------------------------------------------
+# build & run
+# ----------------------------------------------------------------------------
+note "forge build"
+forge build >/dev/null
+
+FORGE_ARGS=(script "$SCRIPT_PATH" --rpc-url "$RPC_URL" "${SIGNER_ARGS[@]}")
+
+if [[ "$BROADCAST" -eq 1 ]]; then
+  FORGE_ARGS+=(--broadcast)
+else
+  note "DRY RUN -- simulation only, nothing will be broadcast"
+fi
+
+if [[ "$BROADCAST" -eq 1 && "$DO_VERIFY" -eq 1 ]]; then
+  if [[ -n "${VERIFIER:-}" ]]; then
+    FORGE_ARGS+=(--verify --verifier "$VERIFIER")
+    [[ -n "${VERIFIER_URL:-}" ]] && FORGE_ARGS+=(--verifier-url "$VERIFIER_URL")
+    [[ -n "${ETHERSCAN_API_KEY:-}" ]] && FORGE_ARGS+=(--etherscan-api-key "$ETHERSCAN_API_KEY")
+  elif [[ -n "${ETHERSCAN_API_KEY:-}" ]]; then
+    FORGE_ARGS+=(--verify --etherscan-api-key "$ETHERSCAN_API_KEY")
+  else
+    warn "no ETHERSCAN_API_KEY / VERIFIER set -- skipping verification (pass --no-verify to silence)"
+  fi
+fi
+
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+  FORGE_ARGS+=("${EXTRA_ARGS[@]}")
+fi
+
+note "running: forge ${FORGE_ARGS[*]}"
+forge "${FORGE_ARGS[@]}"


### PR DESCRIPTION
## Summary

Render generated projects with a \`script/deploy/deploy.sh\` wrapper that makes \`cast wallet import\` + \`--account\` (or \`--ledger\`) the default signing path. Plaintext \`DEPLOYER_PRIVATE_KEY\` is **hard-rejected** on any chain whose id is not \`31337\` (local anvil) — with a clear error message that tells the operator exactly what to type.

Three files change:

- **\`{{cookiecutter.project_slug}}/script/deploy/deploy.sh\`** (new) — thin wrapper around \`forge script\` that:
  - Sources \`.env\`, queries chain id, sanity-checks the signer.
  - Rejects plaintext \`DEPLOYER_PRIVATE_KEY\` for any chain ≠ 31337.
  - Adds \`--verify\` automatically when \`ETHERSCAN_API_KEY\` or \`VERIFIER\` is set.
  - \`--dry-run\` / \`--no-verify\` / \`--account NAME\` / \`--ledger\` flags.
  - \`-- ...\` passes the remaining args verbatim to \`forge script\` (for \`--sig\`, \`--target-contract\`, env-arg syntax).
- **\`.env.example\`** — drops the cargo-culted \`DEPLOYER_WALLET_ADDRESS=\` line; documents the keystore flow inline; adds commented \`VERIFIER\` / \`VERIFIER_URL\` for Blockscout-family explorers. Tenderly block preserved.
- **\`README.md\` Deployment section** — replaces the one-liner \`forge script ... --private-key\` with a three-step walkthrough: \`cast wallet import\` → configure \`.env\` → dry-run + broadcast.

## Why

Until now the template recommended \`forge script ... --private-key <hex>\` in plaintext, which is fine for anvil but a footgun for mainnet/testnet. The \`Galxe/g-token-vault\` repo (generated from this template) just adopted this pattern after the same friction; pushing it back upstream so every future generated project gets it by default.

## Test plan

- [x] \`bash -n\` syntax-check
- [x] \`deploy.sh --help\` renders the inline docs
- [x] Verified the rejection path on the consuming repo (g-token-vault): plaintext key + Gravity Alpha (chain 1625) → rejected with the keystore how-to; plaintext key + anvil (chain 31337) → accepted with a dev-only warning; missing signer + anvil → helpful error
- [ ] Render a fresh project from this template (\`cookiecutter .\`) and run \`deploy.sh --help\` inside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)