### PR TITLE
Define CI fuzz/invariant profiles; deploy.sh summary + key hygiene

### DIFF
--- a/{{cookiecutter.project_slug}}/foundry.toml
+++ b/{{cookiecutter.project_slug}}/foundry.toml
@@ -11,6 +11,27 @@ cache_path = 'cache'
 optimizer = true
 optimizer_runs = 200
 verbosity = 3
+fuzz = { runs = 256 }
+invariant = { runs = 256, depth = 500 }
+
+# CI fast path (every push / PR) -- same depth as the local default.
+[profile.ci]
+fuzz = { runs = 256 }
+invariant = { runs = 256, depth = 500 }
+
+# Alias referenced by `FOUNDRY_PROFILE=test forge fmt --check` in CI.
+[profile.test]
+fuzz = { runs = 256 }
+
+# Used by the CI test job -- deeper fuzzing / invariants.
+[profile.medium]
+fuzz = { runs = 1000 }
+invariant = { runs = 512, depth = 500 }
+
+# On-demand thorough run (workflow_dispatch / pre-release).
+[profile.intense]
+fuzz = { runs = 10000 }
+invariant = { runs = 1000, depth = 1000 }
 
 [fmt]
 line_length = 120

--- a/{{cookiecutter.project_slug}}/foundry.toml
+++ b/{{cookiecutter.project_slug}}/foundry.toml
@@ -11,17 +11,15 @@ cache_path = 'cache'
 optimizer = true
 optimizer_runs = 200
 verbosity = 3
+# Baseline fuzz/invariant budget. `medium` / `intense` below scale from this.
 fuzz = { runs = 256 }
 invariant = { runs = 256, depth = 500 }
 
-# CI fast path (every push / PR) -- same depth as the local default.
-[profile.ci]
-fuzz = { runs = 256 }
-invariant = { runs = 256, depth = 500 }
-
-# Alias referenced by `FOUNDRY_PROFILE=test forge fmt --check` in CI.
-[profile.test]
-fuzz = { runs = 256 }
+# Profiles referenced by name in .github/workflows/test.yml. Left empty so
+# they inherit [profile.default] -- nothing to keep in sync. Override a key
+# here only if CI should diverge from the local default.
+[profile.ci]   # workflow-level FOUNDRY_PROFILE (fmt / build / sizes)
+[profile.test] # `FOUNDRY_PROFILE=test forge fmt --check`
 
 # Used by the CI test job -- deeper fuzzing / invariants.
 [profile.medium]

--- a/{{cookiecutter.project_slug}}/script/deploy/SimpleToken.s.sol
+++ b/{{cookiecutter.project_slug}}/script/deploy/SimpleToken.s.sol
@@ -15,9 +15,10 @@ contract SimpleTokenDeploy is Script {
     function setUp() public { }
 
     function run() public {
-        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
-
-        vm.startBroadcast(deployerPrivateKey);
+        // No-arg broadcast: forge uses whatever CLI signer was passed
+        // (--account / --ledger / --private-key), so this works on every
+        // signing path. deploy.sh wires that up.
+        vm.startBroadcast();
 
         // Deploy SimpleToken with demo parameters
         token = new SimpleToken(
@@ -31,7 +32,7 @@ contract SimpleTokenDeploy is Script {
         console2.log("Token name:", token.name());
         console2.log("Token symbol:", token.symbol());
         console2.log("Total supply:", token.totalSupply());
-        console2.log("Deployer balance:", token.balanceOf(vm.addr(deployerPrivateKey)));
+        console2.log("Deployer balance:", token.balanceOf(msg.sender));
 
         vm.stopBroadcast();
 
@@ -41,6 +42,6 @@ contract SimpleTokenDeploy is Script {
         console2.log("Address:", address(token));
         console2.log("Chain ID:", block.chainid);
         console2.log("Block Number:", block.number);
-        console2.log("Deployer:", vm.addr(deployerPrivateKey));
+        console2.log("Deployer:", msg.sender);
     }
 }

--- a/{{cookiecutter.project_slug}}/script/deploy/SimpleToken.s.sol
+++ b/{{cookiecutter.project_slug}}/script/deploy/SimpleToken.s.sol
@@ -20,6 +20,11 @@ contract SimpleTokenDeploy is Script {
         // signing path. deploy.sh wires that up.
         vm.startBroadcast();
 
+        // `msg.sender` is the broadcaster only inside the broadcast block;
+        // after vm.stopBroadcast() it reverts to the default script sender.
+        // Capture it here so the summary below logs the right address.
+        address deployer = msg.sender;
+
         // Deploy SimpleToken with demo parameters
         token = new SimpleToken(
             "Tenderly Demo Token", // name
@@ -32,7 +37,7 @@ contract SimpleTokenDeploy is Script {
         console2.log("Token name:", token.name());
         console2.log("Token symbol:", token.symbol());
         console2.log("Total supply:", token.totalSupply());
-        console2.log("Deployer balance:", token.balanceOf(msg.sender));
+        console2.log("Deployer balance:", token.balanceOf(deployer));
 
         vm.stopBroadcast();
 
@@ -42,6 +47,6 @@ contract SimpleTokenDeploy is Script {
         console2.log("Address:", address(token));
         console2.log("Chain ID:", block.chainid);
         console2.log("Block Number:", block.number);
-        console2.log("Deployer:", msg.sender);
+        console2.log("Deployer:", deployer);
     }
 }

--- a/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
+++ b/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
@@ -162,7 +162,7 @@ if [[ "$BROADCAST" -eq 1 ]]; then
     echo "=================================================================="
     echo " deployed (chain $CHAIN_ID) -- $RUN_JSON"
     if command -v jq >/dev/null 2>&1; then
-      jq -r '.transactions[]
+      jq -r '.transactions[]?
                | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
                | "   \(.contractName // "<unknown>")\t\(.contractAddress)"' "$RUN_JSON" || true
     else

--- a/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
+++ b/{{cookiecutter.project_slug}}/script/deploy/deploy.sh
@@ -33,6 +33,10 @@
 #                          (useful for --sig, --target-contract, env-arg passthrough)
 #   -h | --help            show this help and exit
 #
+# On a successful broadcast it prints the deployed contract addresses (parsed
+# from broadcast/<script>/<chainId>/run-latest.json; needs `jq`) plus a short
+# post-deploy checklist.
+#
 set -euo pipefail
 
 # ----------------------------------------------------------------------------
@@ -135,5 +139,43 @@ if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
   FORGE_ARGS+=("${EXTRA_ARGS[@]}")
 fi
 
+# Hand DEPLOYER_PRIVATE_KEY to `forge script` only on the raw-key path. On the
+# --account / --ledger paths forge uses the CLI signer; a stray key left in
+# `.env` (exported by `source .env` above) must not silently shadow it for any
+# script that reads it via vm.env*.
+if [[ "${SIGNER_ARGS[0]}" == "--private-key" ]]; then
+  export DEPLOYER_PRIVATE_KEY
+else
+  unset DEPLOYER_PRIVATE_KEY
+fi
+
 note "running: forge ${FORGE_ARGS[*]}"
 forge "${FORGE_ARGS[@]}"
+
+# ----------------------------------------------------------------------------
+# report -- list the contracts that were just deployed
+# ----------------------------------------------------------------------------
+if [[ "$BROADCAST" -eq 1 ]]; then
+  RUN_JSON="broadcast/$(basename "$SCRIPT_PATH")/$CHAIN_ID/run-latest.json"
+  if [[ -f "$RUN_JSON" ]]; then
+    echo
+    echo "=================================================================="
+    echo " deployed (chain $CHAIN_ID) -- $RUN_JSON"
+    if command -v jq >/dev/null 2>&1; then
+      jq -r '.transactions[]
+               | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
+               | "   \(.contractName // "<unknown>")\t\(.contractAddress)"' "$RUN_JSON" || true
+    else
+      warn "install jq for a parsed address summary; raw broadcast log: $RUN_JSON"
+    fi
+    echo "=================================================================="
+    echo
+    echo "Post-deploy checklist:"
+    echo "  1. Verify each address on the explorer if --verify was skipped."
+    echo "  2. Record the addresses in your deployment registry / README."
+    echo "  3. If ownership should move to a multisig, transfer it now and have"
+    echo "     the multisig accept (e.g. transferOwnership + acceptOwnership)."
+  else
+    warn "broadcast log not found at $RUN_JSON -- check the forge output above"
+  fi
+fi


### PR DESCRIPTION
Ported back from `Galxe/g-token-vault`, which is generated from this template and fixed these gaps downstream. All changes are project-agnostic.

> Stacked on `enforce-keystore-signing` (PR #6) because the `deploy.sh` changes build on it. If #6 lands first, happy to retarget this to `main`.

## Changes

**`foundry.toml` — define the CI profiles the workflow already uses.**
`.github/workflows/test.yml` sets `FOUNDRY_PROFILE: ci`, runs the test step with `FOUNDRY_PROFILE: medium`, and does `FOUNDRY_PROFILE=test forge fmt --check` — but none of `[profile.ci]` / `[profile.test]` / `[profile.medium]` were defined, so they silently fell back to defaults. Adds `fuzz` / `invariant` settings on `[profile.default]` and defines `ci`, `test`, `medium`, plus an `intense` profile for on-demand deep runs (`workflow_dispatch` / pre-release).

**`deploy.sh` — post-deploy summary.**
On a successful broadcast, prints the deployed contract addresses (parsed from `broadcast/<script>/<chainId>/run-latest.json` with `jq`; falls back to a hint + the raw log path if `jq` isn't installed) plus a short post-deploy checklist (verify, record, transfer ownership).

**`deploy.sh` — `DEPLOYER_PRIVATE_KEY` hygiene.**
`source .env` exports everything in `.env`. Now `DEPLOYER_PRIVATE_KEY` is passed through to `forge script` only on the raw-key path and `unset` on the `--account` / `--ledger` paths, so a stray key in `.env` can't silently shadow the CLI signer for a script that reads it via `vm.env*`.

**`SimpleToken.s.sol` — no-arg broadcast.**
Switched from `vm.envUint("DEPLOYER_PRIVATE_KEY")` + `vm.startBroadcast(pk)` (breaks with `--account` / `--ledger`) to a bare `vm.startBroadcast()`, matching `Deploy.s.sol`; uses `msg.sender` for the deployer address.

## Test plan

- [x] `bash -n script/deploy/deploy.sh`
- [x] `foundry.toml` is valid TOML; profile names match what `test.yml` references
- [ ] CI (rendered-template build/test/fmt) green
- [ ] Manual `deploy.sh` against anvil to eyeball the new summary block

🤖 Generated with [Claude Code](https://claude.com/claude-code)